### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 install: ant dist
+dist: precise
 jdk:
 - oraclejdk8
 - oraclejdk7


### PR DESCRIPTION
The CI build was failing because the config automatically changed to `dist: "trusty"` when it was `dist: "precise"` for all the other builds.